### PR TITLE
Fix power-node script to work if more than one node in a cell is off

### DIFF
--- a/warden-legacy-java/bin/power-node
+++ b/warden-legacy-java/bin/power-node
@@ -15,7 +15,7 @@ if [ $cmd = "off" ]; then
     fi
 
 elif [ $cmd = "on" ]; then
-    name=$(sudo lxc-ls --fancy | grep $cellName | grep STOPPED | cut -d\  -f1)
+    name=$(sudo lxc-ls --fancy | grep $cellName | grep STOPPED | cut -d\  -f1 | head -1)
     [ -z "$name" ] && echo "Node with IP $ip not found or is already running" && exit 0
     if sudo lxc-start -d -n $name; then
         echo "Node $ip powered on"


### PR DESCRIPTION
There is still a discrepancy between the script arguments and the outcome:
If more than one node is down, it will restore the first one, and not necessarily the one with the given ip